### PR TITLE
Setting/geolocation response 좌표계 엔티티를 위한 부모 객체 및 변환 코드 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.locationtech.proj4j:proj4j:1.2.2'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    testAnnotationProcessor 'org.projectlombok:lombok' // 테스트를 위한 세팅
+    testImplementation 'org.projectlombok:lombok' // 테스트를 위한 세팅
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
@@ -37,6 +40,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.locationtech.proj4j:proj4j:1.2.2'
+    implementation 'org.locationtech.proj4j:proj4j-epsg:1.4.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
+++ b/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
@@ -1,0 +1,16 @@
+package groom.backend.common.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@MappedSuperclass
+@Getter
+@Setter
+public class GeoEntity {
+  private String EPSG;
+  private Float lat;
+  private Float lng;
+}

--- a/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
+++ b/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
 
-@Entity
 @MappedSuperclass
 @Getter
 @Setter

--- a/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
+++ b/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
@@ -1,0 +1,34 @@
+package groom.backend.common.listener;
+
+import groom.backend.common.entity.GeoEntity;
+import groom.backend.common.utils.GeoTransformUtils;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+public class GeoEntityListener {
+
+  @PrePersist
+  @PreUpdate
+  public void beforeSave(Object entity) {
+
+    if (!(entity instanceof GeoEntity geo)) {
+      return;
+    }
+
+    // EPSG가 이미 5181이면 스킵
+    if (geo.getEPSG() != null && geo.getEPSG() == "EPSG:5181") return;
+
+    if (geo.getLat() == null || geo.getLng() == null) return;
+
+    // 좌표 변환 수행
+    Float[] converted = GeoTransformUtils.toEPSG5186(
+            geo.getLat(),
+            geo.getLng(),
+            geo.getEPSG()
+    );
+
+    geo.setLat(converted[0]);
+    geo.setLng(converted[1]);
+    geo.setEPSG("EPSG:5181");
+  }
+}

--- a/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
+++ b/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
@@ -15,13 +15,13 @@ public class GeoEntityListener {
       return;
     }
 
-    // EPSG가 이미 5181이면 스킵
-    if (geo.getEPSG() != null && geo.getEPSG() == "EPSG:5181") return;
+    // EPSG가 이미 4326이면 스킵
+    if (geo.getEPSG() != null && geo.getEPSG() == "EPSG:4326") return;
 
     if (geo.getLat() == null || geo.getLng() == null) return;
 
     // 좌표 변환 수행
-    Float[] converted = GeoTransformUtils.toEPSG5186(
+    Float[] converted = GeoTransformUtils.toEPSG4326(
             geo.getLat(),
             geo.getLng(),
             geo.getEPSG()
@@ -29,6 +29,6 @@ public class GeoEntityListener {
 
     geo.setLat(converted[0]);
     geo.setLng(converted[1]);
-    geo.setEPSG("EPSG:5181");
+    geo.setEPSG("EPSG:4326");
   }
 }

--- a/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
+++ b/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
@@ -9,16 +9,16 @@ public class GeoTransformUtils {
   private static final CoordinateTransformFactory ctFactory = new CoordinateTransformFactory();
 
   /**
-   * EPSG 5186 좌표계 변환
+   * EPSG 4326 좌표계 변환
    * @param lat 위도
    * @param lng 경도
-   * @param EPSGCode 좌표계 예시 : "EPSG:4236"
-   * @return Float[]{x, y} → 5186 좌표 (동북 방향 m 단위)
+   * @param EPSGCode 좌표계 예시 : "EPSG:5181"
+   * @return Float[]{x, y} → 4326 좌표 (동북 방향 m 단위)
    */
-  public static Float[] toEPSG5186(float lat, float lng, String EPSGCode) {
+  public static Float[] toEPSG4326(float lat, float lng, String EPSGCode) {
 
     CoordinateReferenceSystem srcCrs = crsFactory.createFromName(EPSGCode);
-    CoordinateReferenceSystem dstCrs = crsFactory.createFromName("EPSG:5186");
+    CoordinateReferenceSystem dstCrs = crsFactory.createFromName("EPSG:4326");
 
     CoordinateTransform transform = ctFactory.createTransform(srcCrs, dstCrs);
 
@@ -29,10 +29,9 @@ public class GeoTransformUtils {
     try {
       transform.transform(src, dst);
     } catch (Exception e) {
-      throw new RuntimeException("EPSG:5186 좌표 변환 실패", e);
+      throw new RuntimeException("EPSG:4326 좌표 변환 실패", e);
     }
 
-    // EPSG:5186 결과는 x, y (동/북) 순서. 변환 후 지리 좌표계가 아닌 투영 좌표계 사용
     return new Float[]{(float) dst.x, (float) dst.y};
   }
 }

--- a/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
+++ b/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
@@ -1,0 +1,38 @@
+package groom.backend.common.utils;
+
+
+import org.locationtech.proj4j.*;
+
+public class GeoTransformUtils {
+
+  private static final CRSFactory crsFactory = new CRSFactory();
+  private static final CoordinateTransformFactory ctFactory = new CoordinateTransformFactory();
+
+  /**
+   * EPSG 5186 좌표계 변환
+   * @param lat 위도
+   * @param lng 경도
+   * @param EPSGCode 좌표계 예시 : "EPSG:4236"
+   * @return Float[]{x, y} → 5186 좌표 (동북 방향 m 단위)
+   */
+  public static Float[] toEPSG5186(float lat, float lng, String EPSGCode) {
+
+    CoordinateReferenceSystem srcCrs = crsFactory.createFromName(EPSGCode);
+    CoordinateReferenceSystem dstCrs = crsFactory.createFromName("EPSG:5186");
+
+    CoordinateTransform transform = ctFactory.createTransform(srcCrs, dstCrs);
+
+    // Proj4J는 (lng, lat) 순서 사용
+    ProjCoordinate src = new ProjCoordinate(lng, lat);
+    ProjCoordinate dst = new ProjCoordinate();
+
+    try {
+      transform.transform(src, dst);
+    } catch (Exception e) {
+      throw new RuntimeException("EPSG:5186 좌표 변환 실패", e);
+    }
+
+    // EPSG:5186 결과는 x, y (동/북) 순서. 변환 후 지리 좌표계가 아닌 투영 좌표계 사용
+    return new Float[]{(float) dst.x, (float) dst.y};
+  }
+}


### PR DESCRIPTION
## 📌 개요
- 좌표계 정보를 가지는 모든 엔티티의 부모 엔티티와 자동으로 좌표계를 WGS 84 (EPSG:4326)으로 통일하는 기능을 추가한다.

## 🚀 관련 이슈
- #9 

## ✅ 변경 사항
- 좌표계 엔티티 추가

## 📝 상세 내용
- GeoEntity 추가
- proj4j를 이용한 좌표계 변환
- EntityListener를 통한 좌표계 자동 변환

## 📚 관련 문서
-
