### PR TITLE
fix(setting): GeoEntity 필드 변경

### DIFF
--- a/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
+++ b/backend/src/main/java/groom/backend/common/entity/GeoEntity.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class GeoEntity {
-  private String EPSG;
-  private Float lat;
-  private Float lng;
+  private String crs;
+  private Double lat;
+  private Double lng;
 }

--- a/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
+++ b/backend/src/main/java/groom/backend/common/listener/GeoEntityListener.java
@@ -16,19 +16,19 @@ public class GeoEntityListener {
     }
 
     // EPSG가 이미 4326이면 스킵
-    if (geo.getEPSG() != null && geo.getEPSG() == "EPSG:4326") return;
+    if (geo.getCrs() != null && geo.getCrs() == "EPSG:4326") return;
 
     if (geo.getLat() == null || geo.getLng() == null) return;
 
     // 좌표 변환 수행
-    Float[] converted = GeoTransformUtils.toEPSG4326(
+    Double[] converted = GeoTransformUtils.toEPSG4326(
             geo.getLat(),
             geo.getLng(),
-            geo.getEPSG()
+            geo.getCrs()
     );
 
     geo.setLat(converted[0]);
     geo.setLng(converted[1]);
-    geo.setEPSG("EPSG:4326");
+    geo.setCrs("EPSG:4326");
   }
 }

--- a/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
+++ b/backend/src/main/java/groom/backend/common/utils/GeoTransformUtils.java
@@ -15,9 +15,9 @@ public class GeoTransformUtils {
    * @param EPSGCode 좌표계 예시 : "EPSG:5181"
    * @return Float[]{x, y} → 4326 좌표 (동북 방향 m 단위)
    */
-  public static Float[] toEPSG4326(float lat, float lng, String EPSGCode) {
+  public static Double[] toEPSG4326(Double lat, Double lng, String crsCode) {
 
-    CoordinateReferenceSystem srcCrs = crsFactory.createFromName(EPSGCode);
+    CoordinateReferenceSystem srcCrs = crsFactory.createFromName(crsCode);
     CoordinateReferenceSystem dstCrs = crsFactory.createFromName("EPSG:4326");
 
     CoordinateTransform transform = ctFactory.createTransform(srcCrs, dstCrs);
@@ -32,6 +32,6 @@ public class GeoTransformUtils {
       throw new RuntimeException("EPSG:4326 좌표 변환 실패", e);
     }
 
-    return new Float[]{(float) dst.x, (float) dst.y};
+    return new Double[]{(Double) dst.x, (Double) dst.y};
   }
 }


### PR DESCRIPTION
- 좌표계 필드명을 CRS로 변경
- 소수점 자릿수 이슈로 인해 위도 경도 필드의 타입을 Double로 변경

## 📌 개요
-

## 🚀 관련 이슈
- #13 

## ✅ 변경 사항
- 필드 수정
- ERD 문서 업데이트

## 📝 상세 내용
-
-

## 📚 관련 문서
-
