### PR TITLE
feat: GlobalResponseAdvice에서 스웨거 레핑 제외, 리뷰 기본적 CRUD 적용

### DIFF
--- a/backend/src/main/java/groom/backend/common/config/OpenApiConfig.java
+++ b/backend/src/main/java/groom/backend/common/config/OpenApiConfig.java
@@ -36,7 +36,7 @@ public class OpenApiConfig {
 
                 // 접근 주소
                 .addServersItem(new Server()
-                        .url("http://localhost:8080")
+                        .url("http://localhost:8080/api")
                         .description("Development Server")
                 );
     }

--- a/backend/src/main/java/groom/backend/common/response/GlobalResponseAdvice.java
+++ b/backend/src/main/java/groom/backend/common/response/GlobalResponseAdvice.java
@@ -3,7 +3,6 @@ package groom.backend.common.response;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -32,6 +31,12 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
                                   Class<? extends HttpMessageConverter<?>> selectedConverterType,
                                   ServerHttpRequest request, ServerHttpResponse response) {
+
+        // Swagger/OpenAPI 문서 경로는 제외
+        String path = request.getURI().getPath();
+        if (path != null && (path.contains("/v3/api-docs") || path.contains("/swagger-ui") || path.contains("/api-doc"))) {
+            return body;
+        }
 
         // 이미 ApiResponse면 그냥 반환 : 이중검증
         if (body instanceof ApiResponse) {

--- a/backend/src/main/java/groom/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/groom/backend/domain/review/controller/ReviewController.java
@@ -1,0 +1,101 @@
+package groom.backend.domain.review.controller;
+
+import groom.backend.domain.review.dto.request.CreateReviewRequest;
+import groom.backend.domain.review.dto.request.UpdateReviewRequest;
+import groom.backend.domain.review.dto.response.ReviewResponse;
+import groom.backend.domain.review.service.spec.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/reviews")
+@Tag(name = "Review", description = "리뷰 관리 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Autowired
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "리뷰 생성",
+            description = "새로운 리뷰를 생성합니다",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    public ReviewResponse createReview(@Valid @RequestBody CreateReviewRequest request) {
+        return reviewService.createReview(request);
+    }
+
+    @GetMapping("/{reviewId}")
+    @Operation(
+            summary = "리뷰 조회",
+            description = "ID로 리뷰를 조회합니다",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+    })
+    public ReviewResponse getReview(@PathVariable Long reviewId) {
+        return reviewService.getReview(reviewId);
+    }
+
+    @GetMapping("/place/{placeId}")
+    @Operation(
+            summary = "장소별 리뷰 목록 조회",
+            description = "장소 ID로 해당 장소의 모든 리뷰를 조회합니다",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public List<ReviewResponse> getReviewsByPlaceId(@PathVariable Long placeId) {
+        return reviewService.getReviewsByPlaceId(placeId);
+    }
+
+    @PutMapping("/{reviewId}")
+    @Operation(
+            summary = "리뷰 수정",
+            description = "리뷰를 수정합니다",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    public ReviewResponse updateReview(
+            @PathVariable Long reviewId,
+            @Valid @RequestBody UpdateReviewRequest request) {
+        return reviewService.updateReview(reviewId, request);
+    }
+
+    @DeleteMapping("/{reviewId}")
+    @Operation(
+            summary = "리뷰 삭제",
+            description = "리뷰를 삭제합니다",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+    })
+    public void deleteReview(@PathVariable Long reviewId) {
+        reviewService.deleteReview(reviewId);
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/dto/request/CreateReviewRequest.java
+++ b/backend/src/main/java/groom/backend/domain/review/dto/request/CreateReviewRequest.java
@@ -1,0 +1,36 @@
+package groom.backend.domain.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+@Schema(
+    description = "리뷰 생성 요청 DTO",
+    example = "{\"placeId\": 1, \"content\": \"좋은 장소입니다!\", \"rating\": 4.5, \"author\": \"홍길동\", \"imageUrl\": \"https://example.com/image.jpg\"}"
+)
+public record CreateReviewRequest(
+    @Schema(description = "장소 ID (ChargerLocation의 placeId)", example = "1")
+    @NotNull(message = "장소 ID는 필수입니다")
+    Long placeId,
+
+    @Schema(description = "리뷰 내용", example = "좋은 장소입니다!")
+    @NotBlank(message = "리뷰 내용은 필수입니다")
+    @Size(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다")
+    String content,
+
+    @Schema(description = "평점 (0-5점, 0.5 단위)", example = "4.5")
+    @NotNull(message = "평점은 필수입니다")
+    @DecimalMin(value = "0.0", message = "평점은 0점 이상이어야 합니다")
+    @DecimalMax(value = "5.0", message = "평점은 5점 이하여야 합니다")
+    @RatingValidator
+    Double rating,
+
+    @Schema(description = "작성자", example = "홍길동")
+    @NotBlank(message = "작성자는 필수입니다")
+    @Size(max = 100, message = "작성자명은 100자 이하여야 합니다")
+    String author,
+
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+    String imageUrl
+) {
+}

--- a/backend/src/main/java/groom/backend/domain/review/dto/request/RatingValidator.java
+++ b/backend/src/main/java/groom/backend/domain/review/dto/request/RatingValidator.java
@@ -1,0 +1,41 @@
+package groom.backend.domain.review.dto.request;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@jakarta.validation.Constraint(validatedBy = RatingValidator.RatingConstraintValidator.class)
+public @interface RatingValidator {
+    String message() default "평점은 0부터 5까지 0.5 단위로 입력 가능합니다 (예: 0, 0.5, 1, 1.5, ..., 5)";
+    Class<?>[] groups() default {};
+    Class<? extends jakarta.validation.Payload>[] payload() default {};
+
+    class RatingConstraintValidator implements ConstraintValidator<RatingValidator, Double> {
+        @Override
+        public void initialize(RatingValidator constraintAnnotation) {
+        }
+
+        @Override
+        public boolean isValid(Double value, ConstraintValidatorContext context) {
+            if (value == null) {
+                return true; // @NotNull과 함께 사용
+            }
+            
+            // 0 ~ 5 범위 체크
+            if (value < 0.0 || value > 5.0) {
+                return false;
+            }
+            
+            // 0.5 단위인지 체크 (0.5의 배수인지 확인)
+            // 부동소수점 연산의 정밀도 문제를 고려하여 작은 오차 허용
+            double remainder = value % 0.5;
+            return Math.abs(remainder) < 0.001;
+        }
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/dto/request/UpdateReviewRequest.java
+++ b/backend/src/main/java/groom/backend/domain/review/dto/request/UpdateReviewRequest.java
@@ -1,0 +1,27 @@
+package groom.backend.domain.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+@Schema(
+    description = "리뷰 수정 요청 DTO",
+    example = "{\"content\": \"수정된 리뷰 내용입니다!\", \"rating\": 4.5, \"imageUrl\": \"https://example.com/image.jpg\"}"
+)
+public record UpdateReviewRequest(
+    @Schema(description = "리뷰 내용", example = "수정된 리뷰 내용입니다!")
+    @NotBlank(message = "리뷰 내용은 필수입니다")
+    @Size(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다")
+    String content,
+
+    @Schema(description = "평점 (0-5점, 0.5 단위)", example = "4.5")
+    @NotNull(message = "평점은 필수입니다")
+    @DecimalMin(value = "0.0", message = "평점은 0점 이상이어야 합니다")
+    @DecimalMax(value = "5.0", message = "평점은 5점 이하여야 합니다")
+    @RatingValidator
+    Double rating,
+
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+    String imageUrl
+) {
+}

--- a/backend/src/main/java/groom/backend/domain/review/dto/response/ReviewResponse.java
+++ b/backend/src/main/java/groom/backend/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,125 @@
+package groom.backend.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(
+    description = "리뷰 응답 DTO",
+    example = "{\"id\": 1, \"placeId\": 1, \"content\": \"좋은 장소입니다!\", \"rating\": 4.5, \"author\": \"홍길동\", \"imageUrl\": \"https://example.com/image.jpg\", \"isActive\": true, \"createdAt\": \"2025-01-20T10:30:00\", \"updatedAt\": \"2025-01-20T10:30:00\"}"
+)
+public class ReviewResponse {
+
+    @Schema(description = "리뷰 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "장소 ID", example = "1")
+    private Long placeId;
+
+    @Schema(description = "리뷰 내용", example = "좋은 장소입니다!")
+    private String content;
+
+    @Schema(description = "평점", example = "4.5")
+    private Double rating;
+
+    @Schema(description = "작성자", example = "홍길동")
+    private String author;
+
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "활성화 여부", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "생성 시간", example = "2025-01-20T10:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간", example = "2025-01-20T10:30:00")
+    private LocalDateTime updatedAt;
+
+    public ReviewResponse() {}
+
+    public ReviewResponse(Long id, Long placeId, String content, Double rating, String author, 
+                         String imageUrl, Boolean isActive, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.placeId = placeId;
+        this.content = content;
+        this.rating = rating;
+        this.author = author;
+        this.imageUrl = imageUrl;
+        this.isActive = isActive;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPlaceId() {
+        return placeId;
+    }
+
+    public void setPlaceId(Long placeId) {
+        this.placeId = placeId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Double getRating() {
+        return rating;
+    }
+
+    public void setRating(Double rating) {
+        this.rating = rating;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/entity/Review.java
+++ b/backend/src/main/java/groom/backend/domain/review/entity/Review.java
@@ -1,0 +1,51 @@
+package groom.backend.domain.review.entity;
+
+import groom.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "review")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // ChargerLocation의 placeId 참조
+    @Column(nullable = false)
+    private Long placeId;
+
+    // 리뷰 내용
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    // 평점 (0-5점, 0.5 단위)
+    @Column(nullable = false)
+    private Double rating;
+
+    // 작성자 (추후 User 엔티티와 연결 가능)
+    @Column(nullable = false, length = 100)
+    private String author;
+
+    // 이미지 URL
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    // 활성화 여부
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    // 리뷰 수정 메서드
+    public void update(String content, Double rating, String imageUrl) {
+        this.content = content;
+        this.rating = rating;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/mapper/ReviewMapper.java
+++ b/backend/src/main/java/groom/backend/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,43 @@
+package groom.backend.domain.review.mapper;
+
+import groom.backend.domain.review.dto.request.CreateReviewRequest;
+import groom.backend.domain.review.dto.response.ReviewResponse;
+import groom.backend.domain.review.entity.Review;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ReviewMapper {
+
+    public static Review toEntity(CreateReviewRequest request) {
+        return Review.builder()
+                .placeId(request.placeId())
+                .content(request.content())
+                .rating(request.rating())
+                .author(request.author())
+                .imageUrl(request.imageUrl())
+                .isActive(true) // 기본값은 활성화
+                .build();
+    }
+
+    public static ReviewResponse toResponse(Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getPlaceId(),
+                review.getContent(),
+                review.getRating(),
+                review.getAuthor(),
+                review.getImageUrl(),
+                review.getIsActive(),
+                review.getCreatedAt(),
+                review.getUpdatedAt()
+        );
+    }
+
+    public static List<ReviewResponse> toResponseList(List<Review> reviews) {
+        return reviews.stream()
+                .map(ReviewMapper::toResponse)
+                .toList();
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/repository/impl/ReviewRepositoryImpl.java
+++ b/backend/src/main/java/groom/backend/domain/review/repository/impl/ReviewRepositoryImpl.java
@@ -1,0 +1,44 @@
+package groom.backend.domain.review.repository.impl;
+
+import groom.backend.domain.review.entity.Review;
+import groom.backend.domain.review.repository.spec.ReviewRepository;
+import groom.backend.domain.review.repository.spec.jpa.JpaReviewRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+    private final JpaReviewRepository jpaReviewRepository;
+
+    public ReviewRepositoryImpl(JpaReviewRepository jpaReviewRepository) {
+        this.jpaReviewRepository = jpaReviewRepository;
+    }
+
+    @Override
+    public Review save(Review review) {
+        return jpaReviewRepository.save(review);
+    }
+
+    @Override
+    public Optional<Review> findById(Long id) {
+        return jpaReviewRepository.findById(id);
+    }
+
+    @Override
+    public List<Review> findByPlaceId(Long placeId) {
+        return jpaReviewRepository.findByPlaceId(placeId);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaReviewRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return jpaReviewRepository.existsById(id);
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/repository/spec/ReviewRepository.java
+++ b/backend/src/main/java/groom/backend/domain/review/repository/spec/ReviewRepository.java
@@ -1,0 +1,14 @@
+package groom.backend.domain.review.repository.spec;
+
+import groom.backend.domain.review.entity.Review;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewRepository {
+    Review save(Review review);
+    Optional<Review> findById(Long id);
+    List<Review> findByPlaceId(Long placeId);
+    void deleteById(Long id);
+    boolean existsById(Long id);
+}

--- a/backend/src/main/java/groom/backend/domain/review/repository/spec/jpa/JpaReviewRepository.java
+++ b/backend/src/main/java/groom/backend/domain/review/repository/spec/jpa/JpaReviewRepository.java
@@ -1,0 +1,10 @@
+package groom.backend.domain.review.repository.spec.jpa;
+
+import groom.backend.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByPlaceId(Long placeId);
+}

--- a/backend/src/main/java/groom/backend/domain/review/service/impl/ReviewServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/review/service/impl/ReviewServiceImpl.java
@@ -1,0 +1,66 @@
+package groom.backend.domain.review.service.impl;
+
+import groom.backend.domain.review.dto.request.CreateReviewRequest;
+import groom.backend.domain.review.dto.request.UpdateReviewRequest;
+import groom.backend.domain.review.dto.response.ReviewResponse;
+import groom.backend.domain.review.entity.Review;
+import groom.backend.domain.review.mapper.ReviewMapper;
+import groom.backend.domain.review.repository.spec.ReviewRepository;
+import groom.backend.domain.review.service.spec.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    @Transactional
+    public ReviewResponse createReview(CreateReviewRequest request) {
+        Review review = ReviewMapper.toEntity(request);
+        Review savedReview = reviewRepository.save(review);
+        return ReviewMapper.toResponse(savedReview);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReviewResponse getReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다. ID: " + reviewId));
+        return ReviewMapper.toResponse(review);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReviewResponse> getReviewsByPlaceId(Long placeId) {
+        List<Review> reviews = reviewRepository.findByPlaceId(placeId);
+        return ReviewMapper.toResponseList(reviews);
+    }
+
+    @Override
+    @Transactional
+    public ReviewResponse updateReview(Long reviewId, UpdateReviewRequest request) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다. ID: " + reviewId));
+        
+        // 엔티티의 update 메서드 호출 (BaseEntity의 @LastModifiedDate가 자동으로 updatedAt 업데이트)
+        review.update(request.content(), request.rating(), request.imageUrl());
+        
+        Review savedReview = reviewRepository.save(review);
+        return ReviewMapper.toResponse(savedReview);
+    }
+
+    @Override
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        if (!reviewRepository.existsById(reviewId)) {
+            throw new IllegalArgumentException("리뷰를 찾을 수 없습니다. ID: " + reviewId);
+        }
+        reviewRepository.deleteById(reviewId);
+    }
+}

--- a/backend/src/main/java/groom/backend/domain/review/service/spec/ReviewService.java
+++ b/backend/src/main/java/groom/backend/domain/review/service/spec/ReviewService.java
@@ -1,0 +1,34 @@
+package groom.backend.domain.review.service.spec;
+
+import groom.backend.domain.review.dto.request.CreateReviewRequest;
+import groom.backend.domain.review.dto.request.UpdateReviewRequest;
+import groom.backend.domain.review.dto.response.ReviewResponse;
+
+import java.util.List;
+
+public interface ReviewService {
+    /**
+     * 새로운 리뷰를 생성합니다
+     */
+    ReviewResponse createReview(CreateReviewRequest request);
+
+    /**
+     * ID로 리뷰를 조회합니다
+     */
+    ReviewResponse getReview(Long reviewId);
+
+    /**
+     * 장소별 리뷰 목록을 조회합니다
+     */
+    List<ReviewResponse> getReviewsByPlaceId(Long placeId);
+
+    /**
+     * 리뷰를 수정합니다
+     */
+    ReviewResponse updateReview(Long reviewId, UpdateReviewRequest request);
+
+    /**
+     * 리뷰를 삭제합니다
+     */
+    void deleteReview(Long reviewId);
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://db:5432/groom_third
+    url: jdbc:postgresql://localhost:5432/groom_third
     username: dev
     password: dev123
     driver-class-name: org.postgresql.Driver
@@ -22,10 +22,21 @@ spring:
       tags-sorter: alpha
     api-docs:
       path: /v3/api-doc
-    enabled: false
+    enabled: true
 
 server:
   port: 8080
   servlet:
     context-path: /api
   address: 0.0.0.0
+
+api:
+  tmap:
+    api-key: aBYN2RzWLP6cd0eicubRx67Xrm9s5deO58KSSJHJ
+    url: https://apis.openapi.sk.com
+  kakao:
+    rest-api-key: e57fa4c3002e088c8d00b3dd4ab47fae
+    url: https://dapi.kakao.com
+  opendata:
+    url: http://api.data.go.kr/openapi/tn_pubr_public_electr_whlchairhgh_spdchrgr_api
+    api-key: 5a8b1379a32f7e5cd42ad5d7a3db84fef82feab65fcb0f9b486e3134c25d76cf


### PR DESCRIPTION
## 📌 개요
- 1. OpenApiConfig: 서버 URL을 context-path를 포함하도록 수정 (http://localhost:8080/api)
- 2. GlobalResponseAdvice: Swagger/OpenAPI 문서 경로를 ApiResponse 래핑에서 제외
- 3, 리뷰 기본 CRUD 생성(인증 미적용)
- 4. application-dev.yml postgresql db에서 로컬호스트로 변경

## 🚀 관련 이슈
- #25 

## ✅ 변경 사항
- 기능 추가

## 📝 상세 내용
- 1. OpenApiConfig: 서버 URL을 context-path를 포함하도록 수정 (http://localhost:8080/api)
- 2. GlobalResponseAdvice: Swagger/OpenAPI 문서 경로를 ApiResponse 래핑에서 제외
- 리뷰 기본 CRUD 생성(인증 미적용) 

## 📚 관련 문서
-
