### PR TITLE
Feature/path response on failure 장애물 회피 길찾기 시 API 장애 및 오류 대응

### DIFF
--- a/backend/src/main/java/groom/backend/domain/path/dto/response/PathFindResponse.java
+++ b/backend/src/main/java/groom/backend/domain/path/dto/response/PathFindResponse.java
@@ -1,5 +1,6 @@
 package groom.backend.domain.path.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import groom.backend.domain.path.vo.PathNode;
 import groom.backend.domain.path.vo.PathSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +11,8 @@ import java.util.List;
 /**
  * 길찾기 요청에 대한 응답
  * PathNode를 반환
+ * null 값이 아닌 필드만 사용됨
+ * 상속 및 record 사용 불가, DTO 한 개로 관리
  */
 @Setter
 @Getter
@@ -17,10 +20,14 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "길찾기 응답 DTO")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PathFindResponse {
    @Schema(description = "경로 요약 정보")
    private PathSummary pathSummary;
 
    @Schema(description = "경로 상세 노드 리스트")
    private List<PathNode> pathNodeList;
+
+   @Schema(description = "대안 URL scheme, 기본 값은 null이나 경로 정보 미존재시 반드시 존재.")
+   private String uri;
 }

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
@@ -28,7 +28,7 @@ public class PathServiceImpl implements PathService {
     if(!isProvisionArea(pathFindRequest.getStartX(), pathFindRequest.getStartY()) &&
             !isProvisionArea(pathFindRequest.getEndX(), pathFindRequest.getEndY()) ) {
       // TODO : 제공 구역이 아닐 경우, 대안 사용. Kakao URL scheme 반환
-      log.info("서비스 미제공 구역");
+      log.info("서비스 미제공 구역입니다.");
       return null;
     }
 

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
@@ -27,9 +27,12 @@ public class PathServiceImpl implements PathService {
     // 서비스 제공 구역 여부를 검사하는 것이므로, 두 검증에서 모두 false가 나와야 한다. 시도 단위로 제공 시 시군구 단위 정보를 제공하지 않음.
     if(!isProvisionArea(pathFindRequest.getStartX(), pathFindRequest.getStartY()) &&
             !isProvisionArea(pathFindRequest.getEndX(), pathFindRequest.getEndY()) ) {
-      // TODO : 제공 구역이 아닐 경우, 대안 사용. Kakao URL scheme 반환
       log.info("서비스 미제공 구역입니다.");
-      return null;
+      return new PathFindResponse(null, null,
+              kakaoApiClient.pathFindUrlScheme(
+                      pathFindRequest.getStartX(), pathFindRequest.getStartY(),
+                      pathFindRequest.getEndX(), pathFindRequest.getEndY()
+              ));
     }
 
     // API 호출, 값 구해오기

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
@@ -36,10 +36,23 @@ public class PathServiceImpl implements PathService {
     }
 
     // API 호출, 값 구해오기
-    PathFindResponse response = TmapToPathMapper.toPathFindResponseDto(
-            tmapApiClient.tmapApiPathFind(
-                    TmapToPathMapper.toTmapPathFindRequestDto(pathFindRequest)));
-    log.info("response: {}", response);
+    PathFindResponse response = null;
+
+    try {
+      response = TmapToPathMapper.toPathFindResponseDto(
+              tmapApiClient.tmapApiPathFind(
+                      TmapToPathMapper.toTmapPathFindRequestDto(pathFindRequest)));
+      log.info("response: {}", response);
+    } catch (Exception e) {
+      // 4xx 또는 5xx 에러 발생
+      response = new PathFindResponse(null, null,
+              kakaoApiClient.pathFindUrlScheme(
+                      pathFindRequest.getStartX(), pathFindRequest.getStartY(),
+                      pathFindRequest.getEndX(), pathFindRequest.getEndY()
+              ));
+      log.info("Exception occurred by : {}", e.toString());
+    }
+
     // 반환
     return response;
   }

--- a/backend/src/main/java/groom/backend/interfaces/kakao/KakaoApiClient.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/KakaoApiClient.java
@@ -59,10 +59,10 @@ public class KakaoApiClient {
    */
   public String pathFindUrlScheme(Double startX, Double startY, Double endX, Double endY) {
     String url = String.format(
-            "%s/link/map/출발지,%f,%f/목적지,%f,%f",
+            "%s/link/by/walk/출발지,%f,%f/목적지,%f,%f",
             kakaoMapUrl,
-            startX, startY,
-            endX, endY
+            startY, startX,
+            endY, endX
     );
     return url;
   }

--- a/backend/src/main/java/groom/backend/interfaces/kakao/KakaoApiClient.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/KakaoApiClient.java
@@ -6,19 +6,27 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriBuilderFactory;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 @Service
 @Slf4j
 public class KakaoApiClient {
   private final String kakaoApiKey;
+  private final String kakaoMapUrl;
 
   private final RestClient restClient;
 
   public KakaoApiClient(RestClient.Builder builder,
-                       @Value("${api.kakao.url}") String kakaoUrl,
-                       @Value("${api.kakao.rest-api-key}") String kakaoApiKey) {
+                        @Value("${api.kakao.url}") String kakaoUrl,
+                        @Value("${api.kakao.rest-api-key}") String kakaoApiKey,
+                        @Value("${api.kakao.map-url}") String kakaoMapUrl) {
     this.restClient = builder.baseUrl(kakaoUrl).build();
     this.kakaoApiKey = kakaoApiKey;
+    this.kakaoMapUrl = kakaoMapUrl;
   }
 
   public KakaoAddressResponse transferToAddress(Double lng, Double lat) {
@@ -39,5 +47,23 @@ public class KakaoApiClient {
             .retrieve().body(KakaoAddressResponse.class);
     log.info("kakaoApiPathFind response: {}", response.getDocuments().getFirst().getAddress().toString());
     return response;
+  }
+
+  /**
+   * Kakao URL scheme을 이용한 지도 api 반환
+   * @param startX lng
+   * @param startY lat
+   * @param endX lng
+   * @param endY lat
+   * @return
+   */
+  public String pathFindUrlScheme(Double startX, Double startY, Double endX, Double endY) {
+    String url = String.format(
+            "%s/link/map/출발지,%f,%f/목적지,%f,%f",
+            kakaoMapUrl,
+            startX, startY,
+            endX, endY
+    );
+    return url;
   }
 }

--- a/backend/src/main/java/groom/backend/interfaces/tmap/TmapApiClient.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/TmapApiClient.java
@@ -21,6 +21,12 @@ public class TmapApiClient {
     this.tmapApiKey = tmapApiKey;
   }
 
+  /**
+   * Tmap API를 호출해 계단 회피 경로를 가져옵니다.
+   * 4xx 또는 5xx 에러 발생 시 Exception을 던집니다.
+   * @param pathFindRequest
+   * @return
+   */
   public TmapPathFindResponse tmapApiPathFind(TmapPathFindRequest pathFindRequest) {
     Integer version = 1;
     TmapPathFindResponse pathFindResponse = restClient.post().uri(uriBuilder -> uriBuilder

--- a/backend/src/main/java/groom/backend/interfaces/tmap/mapper/TmapToPathMapper.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/mapper/TmapToPathMapper.java
@@ -53,7 +53,7 @@ public class TmapToPathMapper {
       );
       pathNodeList.add(pathNode);
     }
-    return new PathFindResponse(pathSummary, pathNodeList);
+    return new PathFindResponse(pathSummary, pathNodeList, null);
   }
 
   public static TmapPathFindRequest toTmapPathFindRequestDto(PathFindRequest PathFindRequest) {


### PR DESCRIPTION
## 📌 개요
- 서비스 제공 지역이 아니거나 의도치않은 오류로 인해 TMAP API에서 4xx 또는 5xx 오류 발생 시, kakao map api URL scheme을 제공한다.

## 🚀 관련 이슈
- #36 

## ✅ 변경 사항
- Kakao API client에 URL scheme 제공 기능 추가
- Tmap API client 주석 추가
- 길찾기 장애 로직 추가

## 📝 상세 내용
-
-

## 📚 관련 문서
-
