### PR TITLE
Feature/path obstacle avoidance path 장애물 회피 길찾기의 대안 response 상태 코드 수정

### DIFF
--- a/backend/src/main/java/groom/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/groom/backend/common/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         // Swagger UI - 개발환경에서만 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         // 나머지 모든 요청 - 인증 필요
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
 
                 // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 이전에 추가

--- a/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
@@ -43,9 +43,8 @@ public enum ErrorCode {
     REVIEW_DELETE_DENIED(403, "V_003", "본인의 리뷰만 삭제할 수 있습니다"),
 
     // Path Domain Error
-    PATH_END_POINT_TOO_LONG(400, "P_001", "도착지가 너무 멉니다. 가까운 곳으로 다시 시도해주세요."),
-    PATH_SERVICE_UNAVAILABLE_AREA(400, "P_002", "길찾기 서비스를 제공할 수 없는 구역입니다."),
-    PATH_FIND_UNAVAILABLE(500, "P_003", "길찾기 기능을 이용할 수 없습니다."),
+    PATH_SERVICE_UNAVAILABLE_AREA(400, "P_001", "길찾기 서비스를 제공할 수 없는 구간입니다. 너무 멀거나 제공할 수 없습니다."),
+    PATH_FIND_UNAVAILABLE(500, "P_002", "길찾기 기능을 이용할 수 없습니다."),
 
     // Server 에러 (S_xxx)
     INTERNAL_SERVER_ERROR(500, "S_001", "서버 내부 오류가 발생했습니다"),

--- a/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
@@ -42,6 +42,11 @@ public enum ErrorCode {
     REVIEW_UPDATE_DENIED(403, "V_002", "본인의 리뷰만 수정할 수 있습니다"),
     REVIEW_DELETE_DENIED(403, "V_003", "본인의 리뷰만 삭제할 수 있습니다"),
 
+    // Path Domain Error
+    PATH_END_POINT_TOO_LONG(400, "P_001", "도착지가 너무 멉니다. 가까운 곳으로 다시 시도해주세요."),
+    PATH_SERVICE_UNAVAILABLE_AREA(400, "P_002", "길찾기 서비스를 제공할 수 없는 구역입니다."),
+    PATH_FIND_UNAVAILABLE(500, "P_003", "길찾기 기능을 이용할 수 없습니다."),
+
     // Server 에러 (S_xxx)
     INTERNAL_SERVER_ERROR(500, "S_001", "서버 내부 오류가 발생했습니다"),
     DATABASE_ERROR(500, "S_002", "데이터베이스 오류가 발생했습니다");

--- a/backend/src/main/java/groom/backend/domain/path/controller/PathController.java
+++ b/backend/src/main/java/groom/backend/domain/path/controller/PathController.java
@@ -2,11 +2,10 @@ package groom.backend.domain.path.controller;
 
 import groom.backend.domain.path.dto.request.PathFindRequest;
 import groom.backend.domain.path.dto.response.PathFindResponse;
-import groom.backend.domain.path.service.impl.PathService;
+import groom.backend.domain.path.service.spec.PathService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/groom/backend/domain/path/service/impl/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/impl/PathServiceImpl.java
@@ -60,8 +60,7 @@ public class PathServiceImpl implements PathService {
               kakaoApiClient.pathFindUrlScheme(
                       pathFindRequest.getStartX(), pathFindRequest.getStartY(),
                       pathFindRequest.getEndX(), pathFindRequest.getEndY()
-              ));
-      log.info("Exception occurred by : {}", e.toString());
+              )));
     }
 
     // 반환

--- a/backend/src/main/java/groom/backend/domain/path/service/impl/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/impl/PathServiceImpl.java
@@ -1,4 +1,4 @@
-package groom.backend.domain.path.service.spec;
+package groom.backend.domain.path.service.impl;
 
 import groom.backend.common.exception.BusinessException;
 import groom.backend.common.exception.ErrorCode;
@@ -7,7 +7,7 @@ import groom.backend.domain.path.dto.response.PathAddressResponse;
 import groom.backend.domain.path.dto.response.PathFindResponse;
 import groom.backend.domain.path.enums.ProvisionCity;
 import groom.backend.domain.path.enums.ProvisionDistrict;
-import groom.backend.domain.path.service.impl.PathService;
+import groom.backend.domain.path.service.spec.PathService;
 import groom.backend.interfaces.kakao.KakaoApiClient;
 import groom.backend.interfaces.kakao.mapper.KakaoAddressMapper;
 import groom.backend.interfaces.tmap.TmapApiClient;

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathService.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathService.java
@@ -1,4 +1,4 @@
-package groom.backend.domain.path.service.impl;
+package groom.backend.domain.path.service.spec;
 
 import groom.backend.domain.path.dto.request.PathFindRequest;
 import groom.backend.domain.path.dto.response.PathFindResponse;

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathServiceImpl.java
@@ -1,5 +1,7 @@
 package groom.backend.domain.path.service.spec;
 
+import groom.backend.common.exception.BusinessException;
+import groom.backend.common.exception.ErrorCode;
 import groom.backend.domain.path.dto.request.PathFindRequest;
 import groom.backend.domain.path.dto.response.PathAddressResponse;
 import groom.backend.domain.path.dto.response.PathFindResponse;
@@ -28,11 +30,11 @@ public class PathServiceImpl implements PathService {
     if(!isProvisionArea(pathFindRequest.getStartX(), pathFindRequest.getStartY()) &&
             !isProvisionArea(pathFindRequest.getEndX(), pathFindRequest.getEndY()) ) {
       log.info("서비스 미제공 구역입니다.");
-      return new PathFindResponse(null, null,
+      throw new BusinessException(ErrorCode.PATH_SERVICE_UNAVAILABLE_AREA, (Object) new PathFindResponse(null, null,
               kakaoApiClient.pathFindUrlScheme(
                       pathFindRequest.getStartX(), pathFindRequest.getStartY(),
                       pathFindRequest.getEndX(), pathFindRequest.getEndY()
-              ));
+              )));
     }
 
     // API 호출, 값 구해오기
@@ -45,12 +47,12 @@ public class PathServiceImpl implements PathService {
       log.info("response: {}", response);
     } catch (Exception e) {
       // 4xx 또는 5xx 에러 발생
-      response = new PathFindResponse(null, null,
+      log.info("Exception occurred by : {}", e.toString());
+      throw new BusinessException(ErrorCode.PATH_SERVICE_UNAVAILABLE_AREA, (Object) new PathFindResponse(null, null,
               kakaoApiClient.pathFindUrlScheme(
                       pathFindRequest.getStartX(), pathFindRequest.getStartY(),
                       pathFindRequest.getEndX(), pathFindRequest.getEndY()
-              ));
-      log.info("Exception occurred by : {}", e.toString());
+              )));
     }
 
     // 반환


### PR DESCRIPTION
## 📌 개요
- 대안 response의 경우 TMAP API가 실패했을 때의 대안을 사용자에게 제공함.
사용자는 정확한 정보를 얻길 원하므로 비즈니스 로직 상으로는 실패한 트랜잭션
따라서 상태 코드 추가를 통해 더 정확한 상태를 나타내고 이를 처리해야 한다.

## 🚀 관련 이슈
- #77 

## ✅ 변경 사항
- 버그 수정
- 에러 코드 추가
- Path 도메인 경로 권한 허용

## 📝 상세 내용
-
-

## 📚 관련 문서
-
