### PR TITLE
Bug/path kakao api serializer 3rd party API 직렬화 오류 해결

### DIFF
--- a/backend/src/main/java/groom/backend/domain/path/controller/PathNavigateController.java
+++ b/backend/src/main/java/groom/backend/domain/path/controller/PathNavigateController.java
@@ -1,0 +1,53 @@
+package groom.backend.domain.path.controller;
+
+import groom.backend.common.security.AuthUser;
+import groom.backend.domain.path.dto.request.PathFindRequest;
+import groom.backend.domain.path.dto.response.PathFindResponse;
+import groom.backend.domain.path.service.spec.PathService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Path", description = "사용자 경로 추적 상태를 보호자에게 공유하는 API")
+@RequestMapping("/v1/paths")
+public class PathNavigateController {
+  private final PathService pathService;
+
+  @PostMapping("/navigation")
+  @Operation(
+          summary = "길안내 시작",
+          description = "사용자의 위치와 도착지점을 Redis Streams를 통해 보호자에게 실시간 공유를 시작합니다."
+  )
+  @ApiResponses(value = {
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+  })
+  public PathFindResponse startNavigation(@Valid @RequestBody PathFindRequest pathFindRequest,
+                                   @AuthenticationPrincipal AuthUser principal) {
+    // 입력 DTO 유효성 검사 (필드에서 검증)
+
+    // Service 레이어 호출, 사용자 길안내 추적
+    return null;
+  }
+
+  @DeleteMapping("/navigation")
+  @Operation(
+          summary = "길안내 종료",
+          description = "사용자의 길안내 상태를 종료합니다. 프론트엔드에서 수동 조작 또는 도착지 근접 시 자동 트리거됩니다."
+  )
+  @ApiResponses(value = {
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+  })
+  public PathFindResponse endNavigation(@AuthenticationPrincipal AuthUser principal) {
+    // 입력 DTO 유효성 검사 (필드에서 검증)
+
+    // Service 레이어 호출, 사용자 길안내 추적 종료
+    return null;
+  }
+}

--- a/backend/src/main/java/groom/backend/domain/path/service/spec/PathNavigateService.java
+++ b/backend/src/main/java/groom/backend/domain/path/service/spec/PathNavigateService.java
@@ -1,0 +1,15 @@
+package groom.backend.domain.path.service.spec;
+
+// TODO : 길안내 기능으로 확장
+public interface PathNavigateService {
+  /**
+   * 사용자의 위치와 도착지점을 Redis Streams를 통해 보호자에게 실시간 공유를 시작합니다.
+   */
+  public void startNavigation();
+
+  /**
+   * 사용자의 길안내 상태를 종료합니다.
+   * 프론트엔드에서 수동 조작 또는 도착지 근접 시 자동 트리거됩니다.
+   */
+  public void endNavigation();
+}

--- a/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoAddress.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoAddress.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.kakao.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 /**
@@ -11,6 +12,8 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 public class KakaoAddress {
+  @JsonProperty("road_address")
   private KakaoRoadAddress roadAddress;   // 도로명 주소 VO
+  @JsonProperty("address")
   private KakaoLotAddress address;         // 지번 주소 VO
 }

--- a/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoAddressResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoAddressResponse.java
@@ -1,5 +1,7 @@
 package groom.backend.interfaces.kakao.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
@@ -12,6 +14,8 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoAddressResponse {
+  @JsonProperty("documents")
   private List<KakaoAddress> documents;
 }

--- a/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoLotAddress.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoLotAddress.java
@@ -1,5 +1,7 @@
 package groom.backend.interfaces.kakao.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -11,7 +13,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoLotAddress {
+  @JsonProperty("address_name")
   private String addressName;
   @JsonProperty("region_1depth_name")
   private String region1DepthName;
@@ -19,7 +23,10 @@ public class KakaoLotAddress {
   private String region2DepthName;
   @JsonProperty("region_3depth_name")
   private String region3DepthName;
+  @JsonProperty("mountain_yn")
   private String mountainYn;
+  @JsonProperty("main_address_no")
   private String mainAddressNo;
+  @JsonProperty("sub_address_no")
   private String subAddressNo;
 }

--- a/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoRoadAddress.java
+++ b/backend/src/main/java/groom/backend/interfaces/kakao/dto/response/KakaoRoadAddress.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.kakao.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -11,7 +12,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoRoadAddress {
+  @JsonProperty("address_name")
   private String addressName;
   @JsonProperty("region_1depth_name")
   private String region1DepthName;
@@ -19,11 +22,17 @@ public class KakaoRoadAddress {
   private String region2DepthName;
   @JsonProperty("region_3depth_name")
   private String region3DepthName;
+  @JsonProperty("road_name")
   private String roadName;
+  @JsonProperty("underground_yn")
   private String undergroundYn;
+  @JsonProperty("main_building_no")
   private String mainBuildingNo;
+  @JsonProperty("sub_building_no")
   private String subBuildingNo;
+  @JsonProperty("building_name")
   private String buildingName;
+  @JsonProperty("zone_no")
   private String zoneNo;
 
 }

--- a/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathFindResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathFindResponse.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.tmap.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -13,6 +14,7 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TmapPathFindResponse {
   @JsonProperty("features")
   private List<TmapPathNodeFeature> pathNodeList;

--- a/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathGeometry.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathGeometry.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.tmap.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -13,6 +14,7 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TmapPathGeometry {
   @JsonProperty("type")
   private String type;

--- a/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathNodeFeature.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathNodeFeature.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.tmap.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -13,6 +14,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TmapPathNodeFeature {
   @JsonProperty("geometry")
   private TmapPathGeometry geometry;

--- a/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathNodeProperties.java
+++ b/backend/src/main/java/groom/backend/interfaces/tmap/dto/response/TmapPathNodeProperties.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.tmap.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -12,6 +13,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TmapPathNodeProperties {
   @JsonProperty("totalDistance")
   private Integer totalDistance; // 시작점 정보


### PR DESCRIPTION
## 📌 개요
- API의 response 스펙의 모호성으로 인해 RestClient 측에서 직렬화가 제대로 이루어지고 있지 않음으로 추정됨.
- 이에 대한 해결로 JsonIgnorePropterties 및 JsonProperty 명시

## 🚀 관련 이슈
- #108

## ✅ 변경 사항
- 버그 수정
- 문서 업데이트

## 📝 상세 내용
- bug(path): 3rd party API 직렬화 오류 수정
- Json Property 명시하지 않음으로 인한 모호성 제거
- Json Ignore Properties - ignore unknown 옵션을 통해 DTO 스펙에 맞지 않는 필드 무시

## 📚 관련 문서
-
